### PR TITLE
Add yq Version Check

### DIFF
--- a/docs/recipes/k8s/on-prem/scripts/headless/tp-install-on-prem.sh
+++ b/docs/recipes/k8s/on-prem/scripts/headless/tp-install-on-prem.sh
@@ -112,6 +112,13 @@ function check-yq() {
 
     exit 1
   fi
+
+  # Check yq version, which should be 4.x
+  yq_version=$(yq --version | awk '{print $4}' | cut -c 2)
+  if [ "$yq_version" != "4" ]; then
+    echo "Error: yq version 4 is required. Please check your yq version."
+    exit 1
+  fi
 }
 
 function main() {


### PR DESCRIPTION
* **What:** The `check-yq` function in `tp-install-on-prem.sh` has been updated to verify the installed `yq` major version.
* **Why:** The `README.md` requires `yq` version 4, but the script only checked for its existence, not the version. This could lead to runtime errors with incompatible versions. The new check ensures that the correct dependency is in place before execution.